### PR TITLE
Add option to specify make build jobs (--jobs)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/android.py
+++ b/android.py
@@ -455,7 +455,7 @@ def make(opts: AndroidOpts, product: str, target: str):
 
     build_dir = path_join(opts.configure_dir, '%s-%s-%s' % (product, target, opts.configuration))
 
-    make_args = ['-C', build_dir]
+    make_args = ['-j', opts.jobs, '-C', build_dir]
     make_args += ['V=1'] if opts.verbose_make else []
 
     run_command('make', args=make_args, name='make')

--- a/bcl.py
+++ b/bcl.py
@@ -62,7 +62,7 @@ def make_bcl(opts: BclOpts):
 
     build_dir = path_join(opts.configure_dir, 'bcl')
 
-    make_args = ['-C', build_dir, '-C', 'mono']
+    make_args = ['-j', opts.jobs, '-C', build_dir, '-C', 'mono']
     make_args += ['V=1'] if opts.verbose_make else []
 
     run_command('make', args=make_args, name='make bcl')

--- a/cmd_utils.py
+++ b/cmd_utils.py
@@ -44,6 +44,7 @@ def add_base_arguments(parser, default_help):
     mono_sources_default = os.environ.get('MONO_SOURCE_ROOT', '')
 
     parser.add_argument('--verbose-make', action='store_true', default=False, help=default_help)
+    parser.add_argument('--jobs', default='1', help=default_help)
     parser.add_argument('--configure-dir', default=path_join(home, 'mono-configs'), help=default_help)
     parser.add_argument('--install-dir', default=path_join(home, 'mono-installs'), help=default_help)
 

--- a/desktop.py
+++ b/desktop.py
@@ -167,7 +167,7 @@ def configure(opts: DesktopOpts, product: str, target_platform: str, target: str
 def make(opts: DesktopOpts, product: str, target_platform: str, target: str):
     build_dir = path_join(opts.configure_dir, '%s-%s-%s' % (product, target, opts.configuration))
 
-    make_args = ['-C', build_dir]
+    make_args = ['-j', opts.jobs, '-C', build_dir]
     make_args += ['V=1'] if opts.verbose_make else []
 
     run_command('make', args=make_args, name='make')

--- a/llvm.py
+++ b/llvm.py
@@ -64,6 +64,7 @@ def make(opts: BaseOpts, target: str):
     CMAKE_ARGS += [os.environ.get('llvm-%s_CMAKE_ARGS' % target, '')]
 
     make_args = [
+        '-j', opts.jobs,
 	    '-C', '%s/llvm' % opts.mono_source_root,
         '-f', 'build.mk', 'install-llvm',
 		'LLVM_BUILD=%s' % build_dir,

--- a/options.py
+++ b/options.py
@@ -6,6 +6,7 @@ from os.path import abspath
 @dataclass
 class BaseOpts:
     verbose_make: bool
+    jobs: str
     configure_dir: str
     install_dir: str
     mono_source_root: str
@@ -49,6 +50,7 @@ def base_opts_from_args(args):
     from os.path import abspath
     return BaseOpts(
         verbose_make = args.verbose_make,
+        jobs = args.jobs,
         configure_dir = abspath(args.configure_dir),
         install_dir = abspath(args.install_dir),
         mono_source_root = abspath(args.mono_sources),

--- a/wasm.py
+++ b/wasm.py
@@ -128,7 +128,7 @@ def make(opts: RuntimeOpts, product: str, target: str):
     build_dir = path_join(opts.configure_dir, '%s-%s-%s' % (product, target, opts.configuration))
     install_dir = path_join(opts.install_dir, '%s-%s-%s' % (product, target, opts.configuration))
 
-    make_args = ['-C', build_dir]
+    make_args = ['-j', opts.jobs, '-C', build_dir]
     make_args += ['V=1'] if opts.verbose_make else []
 
     make_env = os.environ.copy()


### PR DESCRIPTION
I haven't thoroughly tested yet but it seems to work for `python3 ./linux.py make --target=x86_64 --jobs 7`.