### PR TITLE
Improve --jobs command to support no argument (max jobs)

### DIFF
--- a/android.py
+++ b/android.py
@@ -460,8 +460,8 @@ def make(opts: AndroidOpts, product: str, target: str):
 
     build_dir = path_join(opts.configure_dir, '%s-%s-%s' % (product, target, opts.configuration))
 
-    make_args = ['-j', opts.jobs, '-C', build_dir]
-    make_args += ['V=1'] if opts.verbose_make else []
+    make_args = make_default_args(opts)
+    make_args += ['-C', build_dir]
 
     run_command('make', args=make_args, name='make')
     run_command('make', args=['-C', '%s/mono' % build_dir, 'install'], name='make install mono')

--- a/bcl.py
+++ b/bcl.py
@@ -64,8 +64,8 @@ def make_bcl(opts: BclOpts):
 
     build_dir = path_join(opts.configure_dir, 'bcl')
 
-    make_args = ['-j', opts.jobs, '-C', build_dir, '-C', 'mono']
-    make_args += ['V=1'] if opts.verbose_make else []
+    make_args = make_default_args(opts)
+    make_args += ['-C', build_dir, '-C', 'mono']
 
     run_command('make', args=make_args, name='make bcl')
 
@@ -96,8 +96,8 @@ def make_product(opts: BclOpts, product: str):
 
     mkdir_p(install_dir)
 
-    make_args = ['-C', build_dir, '-C', 'runtime', 'all-mcs', 'build_profiles=%s' % ' '.join(profiles)]
-    make_args += ['V=1'] if opts.verbose_make else []
+    make_args = make_default_args(opts)
+    make_args += ['-C', build_dir, '-C', 'runtime', 'all-mcs', 'build_profiles=%s' % ' '.join(profiles)]
 
     if product == 'desktop-win32':
         make_args += ['PROFILE_PLATFORM=win32'] # Requires patch: 'bcl-profile-platform-override.diff'
@@ -105,8 +105,9 @@ def make_product(opts: BclOpts, product: str):
     run_command('make', args=make_args, name='make profiles')
 
     if opts.tests and len(test_profiles) > 0:
-        test_make_args = ['-C', build_dir, '-C', 'runtime', 'test', 'xunit-test', 'test_profiles=%s' % ' '.join(test_profiles)]
-        test_make_args += ['V=1'] if opts.verbose_make else []
+        test_make_args = make_default_args(opts)
+        test_make_args += ['-C', build_dir, '-C', 'runtime', 'test', 'xunit-test', 'test_profiles=%s' % ' '.join(test_profiles)]
+
         run_command('make', args=test_make_args, name='make tests')
 
     # Copy the bcl profiles to the output directory

--- a/cmd_utils.py
+++ b/cmd_utils.py
@@ -44,7 +44,9 @@ def add_base_arguments(parser, default_help):
     mono_sources_default = os.environ.get('MONO_SOURCE_ROOT', '')
 
     parser.add_argument('--verbose-make', action='store_true', default=False, help=default_help)
-    parser.add_argument('--jobs', default='1', help=default_help)
+    # --jobs supports not passing an argument, in which case the 'const' is used,
+    # which is the number of CPU cores on the host system.
+    parser.add_argument('--jobs', '-j', nargs='?', const=str(os.cpu_count()), default='1', help=default_help)
     parser.add_argument('--configure-dir', default=path_join(home, 'mono-configs'), help=default_help)
     parser.add_argument('--install-dir', default=path_join(home, 'mono-installs'), help=default_help)
 

--- a/desktop.py
+++ b/desktop.py
@@ -167,8 +167,8 @@ def configure(opts: DesktopOpts, product: str, target_platform: str, target: str
 def make(opts: DesktopOpts, product: str, target_platform: str, target: str):
     build_dir = path_join(opts.configure_dir, '%s-%s-%s' % (product, target, opts.configuration))
 
-    make_args = ['-j', opts.jobs, '-C', build_dir]
-    make_args += ['V=1'] if opts.verbose_make else []
+    make_args = make_default_args(opts)
+    make_args += ['-C', build_dir]
 
     run_command('make', args=make_args, name='make')
     run_command('make', args=['-C', '%s/mono' % build_dir, 'install'], name='make install mono')

--- a/ios.py
+++ b/ios.py
@@ -424,8 +424,8 @@ def make(opts: iOSOpts, product: str, target: str):
 
     build_dir = path_join(opts.configure_dir, '%s-%s-%s' % (product, target, opts.configuration))
 
-    make_args = ['-C', build_dir]
-    make_args += ['V=1'] if opts.verbose_make else []
+    make_args = make_default_args(opts)
+    make_args += ['-C', build_dir]
 
     run_command('make', args=make_args, name='make')
     run_command('make', args=['-C', '%s/mono' % build_dir, 'install'], name='make install mono')

--- a/options.py
+++ b/options.py
@@ -111,3 +111,9 @@ def desktop_opts_from_args(args):
         **vars(runtime_opts_from_args(args)),
         with_llvm = args.with_llvm
     )
+
+
+def make_default_args(opts: BaseOpts):
+    make_args = ['-j%s' % opts.jobs]
+    make_args += ['V=1'] if opts.verbose_make else []
+    return make_args

--- a/reference_assemblies.py
+++ b/reference_assemblies.py
@@ -13,8 +13,9 @@ def build(opts: BaseOpts):
 
     mkdir_p(install_dir)
 
-    make_args = ['-C', build_dir, 'build-reference-assemblies']
-    make_args += ['V=1'] if opts.verbose_make else []
+    make_args = make_default_args(opts)
+    make_args += ['-C', build_dir, 'build-reference-assemblies']
+
     run_command('make', args=make_args, name='make build-reference-assemblies')
 
 
@@ -24,8 +25,9 @@ def install(opts: BaseOpts):
 
     mkdir_p(install_dir)
 
-    make_args = ['-C', build_dir, 'install-local', 'DESTDIR=%s' % install_dir, 'prefix=/']
-    make_args += ['V=1'] if opts.verbose_make else []
+    make_args = make_default_args(opts)
+    make_args += ['-C', build_dir, 'install-local', 'DESTDIR=%s' % install_dir, 'prefix=/']
+
     run_command('make', args=make_args, name='make install-local')
 
 

--- a/wasm.py
+++ b/wasm.py
@@ -128,8 +128,8 @@ def make(opts: RuntimeOpts, product: str, target: str):
     build_dir = path_join(opts.configure_dir, '%s-%s-%s' % (product, target, opts.configuration))
     install_dir = path_join(opts.install_dir, '%s-%s-%s' % (product, target, opts.configuration))
 
-    make_args = ['-j', opts.jobs, '-C', build_dir]
-    make_args += ['V=1'] if opts.verbose_make else []
+    make_args = make_default_args(opts)
+    make_args += ['-C', build_dir]
 
     make_env = os.environ.copy()
     make_env['PATH'] = emsdk_root + ':' + make_env['PATH']


### PR DESCRIPTION
Follow-up to #4.

Scripts can now be called with `--jobs` without argument, which will
pass `-j` to `make` and trigger its behavior:

> If the -j option is given without an argument, make will not
> limit the number of jobs that can run simultaneously.