### PR TITLE
Add a formatting script for GitHub Actions and add GitHub metadata

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+patreon: godotengine
+custom: https://godotengine.org/donate

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,30 @@
+---
+name: Bug Report
+about: Report a bug with this repo.
+title: ''
+labels: bug
+assignees: neikeq
+
+---
+
+<!--
+Please search existing issues for potential duplicates before filing yours:
+https://github.com/godotengine/godot-csharp-visualstudio/issues?q=is%3Aissue
+
+Only submit an issue if it is reproducible with the latest stable Godot version.
+-->
+
+**OS/device including version:**
+<!-- Specify GPU model and drivers if graphics-related. -->
+
+
+**Issue description:**
+<!-- What happened, what was expected, and what went wrong. -->
+
+
+**Screenshots of issue:**
+<!--
+This section is optional.
+Drag in an image, or post an image with a link in the form of:
+![Alt Text Here](https://pbs.twimg.com/media/DW5AJnZVAAM1805?format=jpg)
+-->

--- a/.github/ISSUE_TEMPLATE/feature---enhancement-request.md
+++ b/.github/ISSUE_TEMPLATE/feature---enhancement-request.md
@@ -1,0 +1,13 @@
+---
+name: Feature / Enhancement Request
+about: Adding new features or improving existing ones.
+title: ''
+labels: enhancement
+assignees: neikeq
+
+---
+
+<!--
+Please search existing issues for potential duplicates before filing yours:
+https://github.com/godotengine/godot-csharp-visualstudio/issues?q=is%3Aissue
+-->

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -1,0 +1,15 @@
+name: Continuous integration
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Lint repo
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -qq dos2unix recode
+          bash ./format.sh

--- a/format.sh
+++ b/format.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+set -uo pipefail
+IFS=$'\n\t'
+
+# Loops through all text files tracked by Git.
+git grep -zIl '' |
+while IFS= read -rd '' f; do
+    # Exclude csproj and hdr files.
+    if [[ "$f" == *"csproj" ]]; then
+        continue
+    elif [[ "$f" == *"hdr" ]]; then
+        continue
+    elif [[ "$f" == *"diff" ]]; then
+        continue
+    fi
+    # Ensures that files are UTF-8 formatted.
+    recode UTF-8 "$f" 2> /dev/null
+    # Ensures that files have LF line endings.
+    dos2unix "$f" 2> /dev/null
+    # Ensures that files do not contain a BOM.
+    sed -i '1s/^\xEF\xBB\xBF//' "$f"
+    # Ensures that files end with newline characters.
+    tail -c1 < "$f" | read -r _ || echo >> "$f";
+    # Remove trailing space characters.
+    sed -z -i 's/\x20\x0A/\x0A/g' "$f"
+done
+
+git diff > patch.patch
+FILESIZE="$(stat -c%s patch.patch)"
+MAXSIZE=5
+
+# If no patch has been generated all is OK, clean up, and exit.
+if (( FILESIZE < MAXSIZE )); then
+    printf "Files in this commit comply with the formatting rules.\n"
+    rm -f patch.patch
+    exit 0
+fi
+
+# A patch has been created, notify the user, clean up, and exit.
+printf "\n*** The following differences were found between the code "
+printf "and the formatting rules:\n\n"
+cat patch.patch
+printf "\n*** Aborting, please fix your commit(s) with 'git commit --amend' or 'git rebase -i <hash>'\n"
+rm -f patch.patch
+exit 1


### PR DESCRIPTION
The formatting script is `format.sh`, and the file which causes it to be ran automatically on GitHub Actions is
`.github/workflows/ci.yml`. The metadata mentioned in the title includes issue templates and funding information.

The CI check does run because this repo already has other CI checks.