### PR TITLE
Make it a little easier to get a successful working build

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ export MONO_SOURCE_ROOT=$HOME/git/mono
 
 In order to compile mono into Godot for deskop you will need to first build for desktop (see 'Desktop' below), and then Base Class Libraries (see 'Base Class library' below).
 
-Then run the 'copy_bcl' action of the same desktop script you ran configure and make on, specifying the same target platforms you used before. This will copy the bcl runtime into the runtime directories that the subsequent Godot build (using `copy_mono_root=yes`) expects to find them in.
+Then run the 'copy-bcl' action of the same desktop script you ran configure and make on, specifying the same target platforms you used before. This will copy the bcl runtime into the runtime directories that the subsequent Godot build (using `copy_mono_root=yes`) expects to find them in.
 e.g.
-`./linux.py copy_bcl --target=x86 --target=x86_64`
+`./linux.py copy-bcl --target=x86 --target=x86_64`
 
-Then you'll need to compile Godot using `copy_mono_root=yes` and `mono_static=yes`
+Then you'll need to compile Godot using `copy_mono_root=yes`
 e.g.
-`scons -j6 target=release_debug tools=yes module_mono_enabled=yes copy_mono_root=yes mono_static=yes mono_prefix="$HOME/mono-installs/desktop-linux-x86_64-release"`
+`scons -j6 target=release_debug tools=yes module_mono_enabled=yes copy_mono_root=yes mono_prefix="$HOME/mono-installs/desktop-linux-x86_64-release"`
 
 
 ## Desktop

--- a/README.md
+++ b/README.md
@@ -30,6 +30,19 @@ export MONO_SOURCE_ROOT=$HOME/git/mono
 - OSXCROSS is supported expect for building the Mono cross-compilers.
 - Building on Windows is not supported. It's possible to use Cygwin or WSL (Windows Subsystem for Linux) but this hasn't been tested.
 
+## Compiling Godot for Desktop with this Runtime
+
+In order to compile mono into Godot for deskop you will need to first build for desktop (see 'Desktop' below), and then Base Class Libraries (see 'Base Class library' below).
+
+Then run the 'copy_bcl' action of the same desktop script you ran configure and make on, specifying the same target platforms you used before. This will copy the bcl runtime into the runtime directories that the subsequent Godot build (using `copy_mono_root=yes`) expects to find them in.
+e.g.
+`./linux.py copy_bcl --target=x86 --target=x86_64`
+
+Then you'll need to compile Godot using `copy_mono_root=yes` and `mono_static=yes`
+e.g.
+`scons -j6 target=release_debug tools=yes module_mono_enabled=yes copy_mono_root=yes mono_static=yes mono_prefix="$HOME/mono-installs/desktop-linux-x86_64-release"`
+
+
 ## Desktop
 
 ```bash

--- a/bcl.py
+++ b/bcl.py
@@ -27,6 +27,19 @@ test_profiles_table = {
     'wasm': ['wasm']
 }
 
+def get_install_dir(opts: BaseOpts, product: str):
+    return path_join(opts.install_dir, '%s-bcl' % product)
+
+def get_profile_dir(profile: str, product: str):
+    if product == 'desktop-win32':
+        return profile + '-win32'
+    else:
+        return profile
+
+def get_profile_install_dirs(opts: BaseOpts, product: str):
+    install_dir = get_install_dir(opts, product)
+    profiles = profiles_table[product]
+    return [path_join(install_dir, get_profile_dir(profile, product)) for profile in profiles]
 
 def configure_bcl(opts: BclOpts):
     stamp_file = path_join(opts.configure_dir, '.stamp-bcl-configure')
@@ -92,7 +105,7 @@ def make_product(opts: BclOpts, product: str):
     profiles = profiles_table[product]
     test_profiles = test_profiles_table[product]
 
-    install_dir = path_join(opts.install_dir, '%s-bcl' % product)
+    install_dir = get_install_dir(opts, product)
 
     mkdir_p(install_dir)
 
@@ -113,7 +126,7 @@ def make_product(opts: BclOpts, product: str):
     # Copy the bcl profiles to the output directory
     from distutils.dir_util import copy_tree
     for profile in profiles:
-        profile_dir = profile + '-win32' if product == 'desktop-win32' else profile
+        profile_dir = get_profile_dir(profile, product)
         copy_tree('%s/mcs/class/lib/%s' % (opts.mono_source_root, profile_dir), '%s/%s' % (install_dir, profile_dir))
 
     # Remove unneeded files
@@ -149,7 +162,7 @@ def make_product(opts: BclOpts, product: str):
 def clean_product(opts: BclOpts, product: str):
     clean_bcl(opts)
 
-    install_dir = path_join(opts.install_dir, '%s-bcl' % product)
+    install_dir = get_install_dir(opts, product)
     rm_rf(install_dir)
 
 

--- a/desktop.py
+++ b/desktop.py
@@ -198,6 +198,12 @@ def make(opts: DesktopOpts, product: str, target_platform: str, target: str):
     if opts.strip_libs:
         strip_libs(opts, product, target_platform, target)
 
+def copy_bcl(opts: DesktopOpts, product: str, target_platform: str, target: str):
+    from distutils.dir_util import copy_tree
+    from bcl import get_profile_install_dirs
+    dest_dir = path_join(opts.install_dir, '%s-%s-%s' % (product, target, opts.configuration), 'lib/mono/4.5')
+    for src_dir in get_profile_install_dirs(opts, 'desktop'):
+        copy_tree(src_dir, dest_dir)
 
 def clean(opts: DesktopOpts, product: str, target_platform: str, target: str):
     rm_rf(
@@ -215,13 +221,14 @@ def run_main(raw_args, target_platform):
     actions = OrderedDict()
     actions['configure'] = configure
     actions['make'] = make
+    actions['copy_bcl'] = copy_bcl
     actions['clean'] = clean
 
     parser = cmd_utils.build_arg_parser(description='Builds the Mono runtime for the Desktop')
 
     default_help = 'default: %(default)s'
 
-    parser.add_argument('action', choices=['configure', 'make', 'clean'])
+    parser.add_argument('action', choices=['configure', 'make', 'copy_bcl', 'clean'])
     parser.add_argument('--target', choices=targets[target_platform], action='append', required=True)
     parser.add_argument('--with-llvm', action='store_true', default=False, help=default_help)
 

--- a/desktop.py
+++ b/desktop.py
@@ -203,6 +203,8 @@ def copy_bcl(opts: DesktopOpts, product: str, target_platform: str, target: str)
     from bcl import get_profile_install_dirs
     dest_dir = path_join(opts.install_dir, '%s-%s-%s' % (product, target, opts.configuration), 'lib/mono/4.5')
     for src_dir in get_profile_install_dirs(opts, 'desktop'):
+        if not os.path.isdir(src_dir):
+            raise BuildError('BCL source directory does not exist: %s. The BCL must be built prior to this.' % src_dir)
         copy_tree(src_dir, dest_dir)
 
 def clean(opts: DesktopOpts, product: str, target_platform: str, target: str):
@@ -221,14 +223,14 @@ def run_main(raw_args, target_platform):
     actions = OrderedDict()
     actions['configure'] = configure
     actions['make'] = make
-    actions['copy_bcl'] = copy_bcl
+    actions['copy-bcl'] = copy_bcl
     actions['clean'] = clean
 
     parser = cmd_utils.build_arg_parser(description='Builds the Mono runtime for the Desktop')
 
     default_help = 'default: %(default)s'
 
-    parser.add_argument('action', choices=['configure', 'make', 'copy_bcl', 'clean'])
+    parser.add_argument('action', choices=['configure', 'make', 'copy-bcl', 'clean'])
     parser.add_argument('--target', choices=targets[target_platform], action='append', required=True)
     parser.add_argument('--with-llvm', action='store_true', default=False, help=default_help)
 


### PR DESCRIPTION
This PR is intended to make it easier to build Godot with a patched mono build (see https://github.com/godotengine/godot/pull/42039).

The main feature is a new 'copy_bcl' action for the desktop.py script, but I have also added section to the README to document the process.
