### PR TITLE
Android: Force using python3 for `make_standalone_toolchain.py`

### DIFF
--- a/android.py
+++ b/android.py
@@ -415,9 +415,9 @@ def make_standalone_toolchain(opts: AndroidOpts, target: str, api: str):
     if os.path.isdir(path_join(install_dir, 'bin')):
         return # Looks like it's already there, so no need to re-create it
     command = path_join(opts.android_ndk_root, 'build', 'tools', 'make_standalone_toolchain.py')
-    args = ['--verbose', '--force', '--api=' + api, '--arch=' + AndroidTargetTable.archs[target],
+    args = [command, '--verbose', '--force', '--api=' + api, '--arch=' + AndroidTargetTable.archs[target],
             '--install-dir=' + install_dir]
-    run_command(command, args=args, name='make_standalone_toolchain')
+    run_command('python3', args=args, name='make_standalone_toolchain')
 
 
 def strip_libs(opts: AndroidOpts, product: str, target: str, api: str):


### PR DESCRIPTION
This allows using the script on a system without Python 2 installed.
(`make_standalone_toolchain.py` uses `/usr/bin/env python` as shebang.)

Note that as of NDK r19 and later (i.e. anything we'd support now), `make_standalone_toolchain.py` is deprecated and we should look into using the new system: https://developer.android.com/ndk/guides/other_build_systems