### PR TITLE
Allow dependabot to check GitHub actions daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Trying to make sure each repo has the same version of GitHub action applied to each, this PR allows dependabot to submit PRs with version bumps automatically for each of the GitHub actions which this project uses.