### PR TITLE
CI: Build with Mono 6.12.0.111 and Emscripten 1.39.7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
     steps:
       - name: Set Environment Variables
         run: |
-          echo "::set-env name=MONO_SOURCE_ROOT::$GITHUB_WORKSPACE/mono_sources"
+          echo "MONO_SOURCE_ROOT=$GITHUB_WORKSPACE/mono_sources" >> $GITHUB_ENV
       - name: Install Dependencies (x86)
         if: matrix.target == 'x86'
         run: |
@@ -118,7 +118,7 @@ jobs:
     steps:
       - name: Set Environment Variables
         run: |
-          echo "::set-env name=MONO_SOURCE_ROOT::$GITHUB_WORKSPACE/mono_sources"
+          echo "MONO_SOURCE_ROOT=$GITHUB_WORKSPACE/mono_sources" >> $GITHUB_ENV
       - name: Install Dependencies (x86)
         if: matrix.target == 'x86'
         run: |
@@ -192,7 +192,7 @@ jobs:
     steps:
       - name: Set Environment Variables
         run: |
-          echo "::set-env name=MONO_SOURCE_ROOT::$GITHUB_WORKSPACE/mono_sources"
+          echo "MONO_SOURCE_ROOT=$GITHUB_WORKSPACE/mono_sources" >> $GITHUB_ENV
       - name: Install Dependencies
         run: |
           brew install autoconf automake libtool pkg-config cmake python3
@@ -256,7 +256,7 @@ jobs:
     steps:
       - name: Set Environment Variables
         run: |
-          echo "::set-env name=MONO_SOURCE_ROOT::$GITHUB_WORKSPACE/mono_sources"
+          echo "MONO_SOURCE_ROOT=$GITHUB_WORKSPACE/mono_sources" >> $GITHUB_ENV
       - name: Install Dependencies
         run: |
           brew install autoconf automake libtool pkg-config cmake python3
@@ -326,7 +326,7 @@ jobs:
     steps:
       - name: Set Environment Variables
         run: |
-          echo "::set-env name=MONO_SOURCE_ROOT::$GITHUB_WORKSPACE/mono_sources"
+          echo "MONO_SOURCE_ROOT=$GITHUB_WORKSPACE/mono_sources" >> $GITHUB_ENV
       - name: Install Dependencies
         run: |
           brew install autoconf automake libtool pkg-config cmake python3
@@ -414,7 +414,7 @@ jobs:
     steps:
       - name: Set Environment Variables
         run: |
-          echo "::set-env name=MONO_SOURCE_ROOT::$GITHUB_WORKSPACE/mono_sources"
+          echo "MONO_SOURCE_ROOT=$GITHUB_WORKSPACE/mono_sources" >> $GITHUB_ENV
       - name: Install Dependencies
         run: |
           sudo apt-get -y update
@@ -426,8 +426,8 @@ jobs:
           androidsdk "platforms;${ANDROID_PLATFORM}"
           androidsdk "ndk-bundle"
           androidsdk "cmake;${ANDROID_CMAKE_VERSION}"
-          echo "::set-env name=ANDROID_SDK_ROOT::$HOME/snap/androidsdk/current/"
-          echo "::set-env name=ANDROID_NDK_ROOT::$ANDROID_SDK_ROOT/ndk-bundle"
+          echo "ANDROID_SDK_ROOT=$HOME/snap/androidsdk/current/" >> $GITHUB_ENV
+          echo "ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk-bundle" >> $GITHUB_ENV
       - name: Cache Mono Sources
         id: cache_mono_sources
         uses: actions/cache@v1.2.0
@@ -540,7 +540,7 @@ jobs:
     steps:
       - name: Set Environment Variables
         run: |
-          echo "::set-env name=MONO_SOURCE_ROOT::$GITHUB_WORKSPACE/mono_sources"
+          echo "MONO_SOURCE_ROOT=$GITHUB_WORKSPACE/mono_sources" >> $GITHUB_ENV
       - name: Install Dependencies
         run: |
           sudo apt-get -y update
@@ -556,8 +556,8 @@ jobs:
           androidsdk "platforms;${ANDROID_PLATFORM}"
           androidsdk "ndk-bundle"
           androidsdk "cmake;${ANDROID_CMAKE_VERSION}"
-          echo "::set-env name=ANDROID_SDK_ROOT::$HOME/snap/androidsdk/current/"
-          echo "::set-env name=ANDROID_NDK_ROOT::$ANDROID_SDK_ROOT/ndk-bundle"
+          echo "ANDROID_SDK_ROOT=$HOME/snap/androidsdk/current/" >> $GITHUB_ENV
+          echo "ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT/ndk-bundle" >> $GITHUB_ENV
       - name: Cache Mono Sources
         id: cache_mono_sources
         uses: actions/cache@v1.2.0
@@ -640,7 +640,7 @@ jobs:
     steps:
       - name: Set Environment Variables
         run: |
-          echo "::set-env name=MONO_SOURCE_ROOT::$GITHUB_WORKSPACE/mono_sources"
+          echo "MONO_SOURCE_ROOT=$GITHUB_WORKSPACE/mono_sources" >> $GITHUB_ENV
       - name: Install Dependencies
         run: |
           sudo apt-get -y update
@@ -726,7 +726,7 @@ jobs:
           key: ${{ runner.os }}-${{ env.MONO_TAG }}-llvm-${{ matrix.target }}
       - name: Set Environment Variables
         run: |
-          echo "::set-env name=MONO_SOURCE_ROOT::$GITHUB_WORKSPACE/mono_sources"
+          echo "MONO_SOURCE_ROOT=$GITHUB_WORKSPACE/mono_sources" >> $GITHUB_ENV
       - name: Install Dependencies (Linux)
         if: steps.cache_llvm.outputs.cache-hit != 'true' && runner.os == 'Linux'
         run: |
@@ -800,7 +800,7 @@ jobs:
     steps:
       - name: Set Environment Variables
         run: |
-          echo "::set-env name=MONO_SOURCE_ROOT::$GITHUB_WORKSPACE/mono_sources"
+          echo "MONO_SOURCE_ROOT=$GITHUB_WORKSPACE/mono_sources" >> $GITHUB_ENV
       - name: Install Dependencies
         run: |
           sudo apt-get -y update

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,9 +27,9 @@ on:
 
 env:
   # Use SHA instead of the branch for caching purposes
-  MONO_TAG: mono-6.8.0.123
+  MONO_TAG: mono-6.12.0.111
   PYTHON_VERSION: 3.8
-  EMSDK_VERSION: 1.38.47-upstream
+  EMSDK_VERSION: 1.39.9
   ANDROID_PLATFORM: android-29
   ANDROID_CMAKE_VERSION: 3.6.4111459
   ANDROID_API: 21

--- a/files/patches/mono_ios_asl_log_deprecated.diff
+++ b/files/patches/mono_ios_asl_log_deprecated.diff
@@ -6,8 +6,8 @@ index 3cb127bad59..30ff5edc307 100644
   */
  #include <config.h>
  
--#if defined(HOST_WATCHOS) && (__WATCH_OS_VERSION_MIN_REQUIRED >= __WATCHOS_3_0)
-+#if (defined(HOST_WATCHOS) && (__WATCH_OS_VERSION_MIN_REQUIRED >= __WATCHOS_3_0)) \
+-#if (defined(HOST_WATCHOS) && (__WATCH_OS_VERSION_MIN_REQUIRED >= __WATCHOS_3_0)) || defined(HOST_MACCAT)
++#if (defined(HOST_WATCHOS) && (__WATCH_OS_VERSION_MIN_REQUIRED >= __WATCHOS_3_0)) || defined(HOST_MACCAT) \
 +	|| (defined(HOST_IOS) && (__ENVIRONMENT_IPHONE_OS_VERSION_MIN_REQUIRED__ >= 100000))
  /* emitted by clang:
   *   > /Users/lewurm/work/mono-watch4/mono/utils/mono-log-darwin.c:35:2: error: 'asl_log' is \

--- a/format.sh
+++ b/format.sh
@@ -6,12 +6,14 @@ IFS=$'\n\t'
 # Loops through all text files tracked by Git.
 git grep -zIl '' |
 while IFS= read -rd '' f; do
-    # Exclude csproj and hdr files.
+    # Exclude csproj and hdr files, and patches.
     if [[ "$f" == *"csproj" ]]; then
         continue
     elif [[ "$f" == *"hdr" ]]; then
         continue
     elif [[ "$f" == *"diff" ]]; then
+        continue
+    elif [[ "$f" == *"patch" ]]; then
         continue
     fi
     # Ensures that files are UTF-8 formatted.

--- a/ios.py
+++ b/ios.py
@@ -96,6 +96,9 @@ def setup_ios_device_template(env: dict, opts: iOSOpts, target: str):
         'ac_cv_func_futimens=no',
         'ac_cv_func_utimensat=no',
         'ac_cv_func_shm_open_working_with_mmap=no',
+        'ac_cv_func_pthread_jit_write_protect_np=no',
+        'ac_cv_func_preadv=no',
+        'ac_cv_func_pwritev=no',
         'mono_cv_sizeof_sunpath=104',
         'mono_cv_uscore=yes'
     ]
@@ -121,13 +124,7 @@ def setup_ios_device_template(env: dict, opts: iOSOpts, target: str):
     	'-DSMALL_CONFIG', '-D_XOPEN_SOURCE', '-DHOST_IOS', '-DHAVE_LARGE_FILE_SUPPORT=1'
     ]
 
-    LDFLAGS = []
-
-    # https://github.com/mono/mono/issues/19393
-    if os.environ.get('DISABLE_NO_WEAK_IMPORTS', '0') != '1':
-        LDFLAGS += ['-Wl,-no_weak_imports']
-
-    LDFLAGS += [
+    LDFLAGS = [
     	'-arch %s' % arch,
     	'-framework', 'CoreFoundation',
     	'-lobjc', '-lc++'
@@ -225,6 +222,9 @@ def setup_ios_simulator_template(env: dict, opts: iOSOpts, target: str):
         'ac_cv_func_futimens=no',
         'ac_cv_func_utimensat=no',
         'ac_cv_func_shm_open_working_with_mmap=no',
+        'ac_cv_func_pthread_jit_write_protect_np=no',
+        'ac_cv_func_preadv=no',
+        'ac_cv_func_pwritev=no',
         'mono_cv_uscore=yes'
     ]
 

--- a/llvm.py
+++ b/llvm.py
@@ -38,8 +38,8 @@ def make(opts: BaseOpts, target: str):
 
         CMAKE_ARGS += [
             '-DCMAKE_EXE_LINKER_FLAGS="-static"',
-            '-DCROSS_TOOLCHAIN_FLAGS_NATIVE=-DCMAKE_TOOLCHAIN_FILE=%s/external/llvm/cmake/modules/NATIVE.cmake' % opts.mono_source_root,
-            '-DCMAKE_TOOLCHAIN_FILE=%s/external/llvm/cmake/modules/%s.cmake' % (opts.mono_source_root, mxe),
+            '-DCROSS_TOOLCHAIN_FLAGS_NATIVE=-DCMAKE_TOOLCHAIN_FILE=%s/external/llvm-project/llvm/cmake/modules/NATIVE.cmake' % opts.mono_source_root,
+            '-DCMAKE_TOOLCHAIN_FILE=%s/external/llvm-project/llvm/cmake/modules/%s.cmake' % (opts.mono_source_root, mxe),
             '-DLLVM_ENABLE_THREADS=Off',
             '-DLLVM_BUILD_EXECUTION_ENGINE=Off'
         ]
@@ -58,7 +58,7 @@ def make(opts: BaseOpts, target: str):
         replace_in_new_file(
             src_file='%s/sdks/builds/%s.cmake.in' % (opts.mono_source_root, mxe),
             search='@MXE_PATH@', replace=opts.mxe_prefix,
-            dst_file='%s/external/llvm/cmake/modules/%s.cmake' % (opts.mono_source_root, mxe)
+            dst_file='%s/external/llvm-project/llvm/cmake/modules/%s.cmake' % (opts.mono_source_root, mxe)
         )
 
     if target in ['llvm32', 'llvmwin32']:

--- a/patch_emscripten.py
+++ b/patch_emscripten.py
@@ -23,7 +23,6 @@ def main(raw_args):
 
     patches = [
         '%s/sdks/builds/fix-emscripten-8511.diff' % mono_source_root,
-        '%s/sdks/builds/emscripten-pr-8457.diff' % mono_source_root
     ]
 
     from subprocess import Popen


### PR DESCRIPTION
This is what we'll be using for official builds for 3.2.4+.

---

This is an attempt to see if that could fix the Wasm builds. The current failure seems to be due to Mono's buildsystem not being ready yet in 6.8 to use the new `EMSDK` env variable instead of relying on the existence of `~/.emscripten`.