### PR TITLE
CI: Bump Mono to 6.12.0.114 and fix Android 32-bit min API

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,13 +26,17 @@ on:
 # Use ubuntu-latest for the WASM runtime ("machine `wasm32' not recognized" on ubuntu-16.04)
 
 env:
-  # Use SHA instead of the branch for caching purposes
-  MONO_TAG: mono-6.12.0.111
+  # Use SHA or tag instead of the branch for caching purposes.
+  MONO_TAG: mono-6.12.0.114
   PYTHON_VERSION: 3.8
+  # Should match the version that Mono supports.
   EMSDK_VERSION: 1.39.9
+  ANDROID_CMAKE_VERSION: 3.10.2.4988404
+  # These should be synced with the Godot repo.
+  # platform/android/java/app/config.gradle
   ANDROID_PLATFORM: android-29
-  ANDROID_CMAKE_VERSION: 3.6.4111459
-  ANDROID_API: 21
+  ANDROID_API: 18
+  # platform/iphone/detect.py
   IOS_VERSION_MIN: 10.0
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository contains scripts for building the Mono runtime to use with Godot
 The scripts are tested against specific versions of the toolchains used by Godot.
 While they may work with other versions, you might have issues applying patches or compiling, so we recommend using the versions below.
 
-- Mono: 6.12.0.111.
+- Mono: 6.12.0.114.
 - Emscripten: 1.39.9.
 - Android: API level 29.
 


### PR DESCRIPTION
Following up on #22, we should target API level 18 like the Godot source does,
which is used by armv7/x86 builds. 64-bit builds do require API level 21 as a
minimum, but our build scripts handle upgrading this value already.

I upgraded my build containers to use Mono 6.12.0.114 (latest Preview), and also bumped Android CMake version to 3.10.2.4988404 which is what we use in official builds (shouldn't matter much).