### PR TITLE
bcl: Fix copy_bcl for desktop-win32 profile

### DIFF
--- a/desktop.py
+++ b/desktop.py
@@ -225,7 +225,7 @@ def copy_bcl(opts: DesktopOpts, product: str, target_platform: str, target: str)
     from distutils.dir_util import copy_tree
     from bcl import get_profile_install_dirs
     dest_dir = path_join(opts.install_dir, '%s-%s-%s' % (product, target, opts.configuration), 'lib/mono/4.5')
-    for src_dir in get_profile_install_dirs(opts, 'desktop'):
+    for src_dir in get_profile_install_dirs(opts, 'desktop-win32' if target_platform == 'windows' else 'desktop'):
         if not os.path.isdir(src_dir):
             raise BuildError('BCL source directory does not exist: %s. The BCL must be built prior to this.' % src_dir)
         copy_tree(src_dir, dest_dir)


### PR DESCRIPTION
Seems like https://github.com/godotengine/godot/issues/50486 was not due to cross-compilation issues, but to the fact that `windows.py copy_bcl` didn't properly copy the `desktop-win32` BCL, so we were using the `desktop` (POSIX) one.

That's why @bruvzg found that projects exported to Windows with 3.4 beta 1 worked fine, since the export workflow properly uses the `net_4_x-win32` BCL.

---

Got a successful container build (will PR in a bit), currently testing the produced builds to validate.