### PR TITLE
Enable BTLS when building for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ export MONO_SOURCE_ROOT=$HOME/git/mono
 
 ### Notes
 - Python 3.7 or higher is required.
-- OSXCROSS is supported expect for building the Mono cross-compilers.
+- OSXCROSS is supported except for building the Mono cross-compilers.
 - Building on Windows is not supported. It's possible to use Cygwin or WSL (Windows Subsystem for Linux) but this hasn't been tested.
 
 ## Compiling Godot for Desktop with this Runtime

--- a/bcl.py
+++ b/bcl.py
@@ -40,7 +40,7 @@ def get_profile_install_dirs(opts: BaseOpts, product: str):
     profiles = profiles_table[product]
     return [path_join(install_dir, get_profile_dir(profile, product)) for profile in profiles]
 
-def configure_bcl(opts: BclOpts):
+def configure_bcl(opts: BclOpts, product: str):
     stamp_file = path_join(opts.configure_dir, '.stamp-bcl-configure')
 
     if os.path.isfile(stamp_file):
@@ -54,11 +54,20 @@ def configure_bcl(opts: BclOpts):
 
     CONFIGURE_FLAGS = [
         '--disable-boehm',
-        '--disable-btls-lib',
         '--disable-nls',
         '--disable-support-build',
         '--with-mcs-docs=no'
     ]
+
+    if product == 'desktop-win32':
+        CONFIGURE_FLAGS += [
+            '--enable-btls',
+            '--enable-btls-lib'
+        ]
+    else:
+        CONFIGURE_FLAGS += [
+            '--disable-btls-lib'
+        ]
 
     configure = path_join(opts.mono_source_root, 'configure')
     configure_args = CONFIGURE_FLAGS
@@ -84,8 +93,8 @@ def make_bcl(opts: BclOpts):
     touch(stamp_file)
 
 
-def build_bcl(opts: BclOpts):
-    configure_bcl(opts)
+def build_bcl(opts: BclOpts, product: str):
+    configure_bcl(opts, product)
     make_bcl(opts)
 
 
@@ -97,7 +106,7 @@ def clean_bcl(opts: BclOpts):
 
 
 def make_product(opts: BclOpts, product: str):
-    build_bcl(opts)
+    build_bcl(opts, product)
 
     build_dir = path_join(opts.configure_dir, 'bcl')
 

--- a/desktop.py
+++ b/desktop.py
@@ -87,7 +87,8 @@ def setup_desktop_template(env: dict, opts: DesktopOpts, product: str, target_pl
         '--disable-mcs-build',
         '--enable-maintainer-mode',
         '--with-tls=pthread',
-        '--without-ikvm-native'
+        '--without-ikvm-native',
+        '--enable-btls'
     ]
 
     if target_platform == 'windows':
@@ -98,7 +99,6 @@ def setup_desktop_template(env: dict, opts: DesktopOpts, product: str, target_pl
         CONFIGURE_FLAGS += [
             '--disable-iconv',
             '--disable-nls',
-            '--enable-dynamic-btls',
             '--with-sigaltstack=yes',
         ]
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/36958 by enabling BTLS when building Mono for Windows. `--enable-dynamic-btls` was changed to `--enable-btls` in `desktop.py` because https://github.com/mono/mono/pull/3829 appears to have made it so that they're the same. I also corrected what I expect was a typo.
Note: I haven't actually tested this as I don't own a Linux or OSX computer.