### PR TITLE
Fix Mono log spam

### DIFF
--- a/files/patches/fix-mono-log-spam.diff
+++ b/files/patches/fix-mono-log-spam.diff
@@ -1,0 +1,48 @@
+diff --git a/mono/metadata/threadpool-io.c b/mono/metadata/threadpool-io.c
+index fdfef2de91e28..45ac0d84b2429 100644
+--- a/mono/metadata/threadpool-io.c
++++ b/mono/metadata/threadpool-io.c
+@@ -180,6 +180,7 @@ selector_thread_wakeup_drain_pipes (void)
+ {
+ 	gchar buffer [128];
+ 	gint received;
++	static gint warnings_issued = 0;
+
+ 	for (;;) {
+ #if !defined(HOST_WIN32)
+@@ -192,11 +193,16 @@ selector_thread_wakeup_drain_pipes (void)
+ 			 * some unices (like AIX) send ERESTART, which doesn't
+ 			 * exist on some other OSes errno
+ 			 */
+-			if (errno != EINTR && errno != EAGAIN && errno != ERESTART)
++			if (errno != EINTR && errno != EAGAIN && errno != ERESTART) {
+ #else
+-			if (errno != EINTR && errno != EAGAIN)
++			if (errno != EINTR && errno != EAGAIN) {
+ #endif
+-				g_warning ("selector_thread_wakeup_drain_pipes: read () failed, error (%d) %s\n", errno, g_strerror (errno));
++				// limit amount of spam we write
++				if (warnings_issued < 100) {
++					g_warning ("selector_thread_wakeup_drain_pipes: read () failed, error (%d) %s\n", errno, g_strerror (errno));
++					warnings_issued++;
++				}
++			}
+ 			break;
+ 		}
+ #else
+@@ -204,8 +210,13 @@ selector_thread_wakeup_drain_pipes (void)
+ 		if (received == 0)
+ 			break;
+ 		if (received == SOCKET_ERROR) {
+-			if (WSAGetLastError () != WSAEINTR && WSAGetLastError () != WSAEWOULDBLOCK)
+-				g_warning ("selector_thread_wakeup_drain_pipes: recv () failed, error (%d)\n", WSAGetLastError ());
++			if (WSAGetLastError () != WSAEINTR && WSAGetLastError () != WSAEWOULDBLOCK) {
++				// limit amount of spam we write
++				if (warnings_issued < 100) {
++					g_warning ("selector_thread_wakeup_drain_pipes: recv () failed, error (%d)\n", WSAGetLastError ());
++					warnings_issued++;
++				}
++			}
+ 			break;
+ 		}
+ #endif

--- a/patch_mono.py
+++ b/patch_mono.py
@@ -27,6 +27,7 @@ def main(raw_args):
 
     patches = [
         'fix-mono-android-tkill.diff',
+        'fix-mono-log-spam.diff',
         'mono-dbg-agent-clear-tls-instead-of-abort.diff',
         'bcl-profile-platform-override.diff',
         'mono_ios_asl_log_deprecated.diff',


### PR DESCRIPTION
Port of https://github.com/mono/mono/pull/20980, which itself is based on https://github.com/Unity-Technologies/mono/commit/37dc7aae643fa1d86f183044379352eac074d96e. Applies cleanly on the latest `2020-02` branch.

This prevents Mono logs from being spammed, which could result in log file sizes in the dozens of gigabytes.

## Patch log

```
❯ ./patch_mono.py --mono-sources mono                              
Running: patch -N -p1 < /home/hugo/Documents/Git/godotengine/godot-mono-builds/files/patches/fix-mono-android-tkill.diff
patching file mono/metadata/threads.c
Hunk #1 succeeded at 78 (offset 1 line).
patching file mono/utils/mono-threads-posix.c
Hunk #1 succeeded at 32 (offset 1 line).
Running: patch -N -p1 < /home/hugo/Documents/Git/godotengine/godot-mono-builds/files/patches/fix-mono-log-spam.diff
patching file mono/metadata/threadpool-io.c
Hunk #1 succeeded at 179 (offset -1 lines).
Hunk #2 succeeded at 192 (offset -1 lines).
Hunk #3 succeeded at 209 (offset -1 lines).
Running: patch -N -p1 < /home/hugo/Documents/Git/godotengine/godot-mono-builds/files/patches/mono-dbg-agent-clear-tls-instead-of-abort.diff
patching file mono/mini/debugger-agent.c
Hunk #1 succeeded at 4172 (offset 84 lines).
Running: patch -N -p1 < /home/hugo/Documents/Git/godotengine/godot-mono-builds/files/patches/bcl-profile-platform-override.diff
patching file mcs/build/rules.make
Running: patch -N -p1 < /home/hugo/Documents/Git/godotengine/godot-mono-builds/files/patches/mono_ios_asl_log_deprecated.diff
patching file mono/utils/mono-log-darwin.c
Running: patch -N -p1 < /home/hugo/Documents/Git/godotengine/godot-mono-builds/files/patches/wasm_m2n_trampolines_hook.diff
patching file mono/mini/aot-runtime-wasm.c
patching file mono/mini/wasm_m2n_invoke.g.h
Running: patch -N -p1 < /home/hugo/Documents/Git/godotengine/godot-mono-builds/files/patches/offsets-tool-extra-cflags_new.diff
patching file mono/tools/offsets-tool/offsets-tool.py
```