### PR TITLE
Windows: Configure with `--enable-btls-lib` to build BTLS dll

### DIFF
--- a/desktop.py
+++ b/desktop.py
@@ -88,7 +88,8 @@ def setup_desktop_template(env: dict, opts: DesktopOpts, product: str, target_pl
         '--enable-maintainer-mode',
         '--with-tls=pthread',
         '--without-ikvm-native',
-        '--enable-btls'
+        '--enable-btls',
+        '--enable-btls-lib'
     ]
 
     if target_platform == 'windows':
@@ -209,6 +210,14 @@ def configure(opts: DesktopOpts, product: str, target_platform: str, target: str
 
 def make(opts: DesktopOpts, product: str, target_platform: str, target: str):
     build_dir = path_join(opts.configure_dir, '%s-%s-%s' % (product, target, opts.configuration))
+
+    if target_platform == 'windows':
+        mxe = 'mxe-Win64' if target == 'x86_64' else 'mxe-Win32'
+        replace_in_new_file(
+            src_file='%s/sdks/builds/%s.cmake.in' % (opts.mono_source_root, mxe),
+            search='@MXE_PATH@', replace=opts.mxe_prefix,
+            dst_file='%s/mono/btls/%s.cmake' % (opts.mono_source_root, mxe)
+        )
 
     make_args = make_default_args(opts)
     make_args += ['-C', build_dir]

--- a/files/patches/btls-cmake-args-linux-mingw.diff
+++ b/files/patches/btls-cmake-args-linux-mingw.diff
@@ -1,0 +1,33 @@
+diff --git a/configure.ac b/configure.ac
+index 088128e5e74..54693aace64 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -5918,6 +5918,8 @@ if test "x$enable_btls" = "xyes"; then
+ 				if test "x$HAVE_YASM" != "xyes"; then
+ 					BTLS_CMAKE_ARGS="-DOPENSSL_NO_ASM=1"
+ 				fi
++				mono_btls_dir_abs=`cd $srcdir && pwd`/mono/btls
++				BTLS_CMAKE_ARGS="$BTLS_CMAKE_ARGS -DCYGWIN=TRUE -DCMAKE_TOOLCHAIN_FILE=\"$mono_btls_dir_abs/mxe-Win32.cmake\""
+ 				;;
+ 		esac
+ 		;;
+@@ -5929,6 +5931,8 @@ if test "x$enable_btls" = "xyes"; then
+ 				if test "x$HAVE_YASM" != "xyes"; then
+ 					BTLS_CMAKE_ARGS="-DOPENSSL_NO_ASM=1"
+ 				fi
++				mono_btls_dir_abs=`cd $srcdir && pwd`/mono/btls
++				BTLS_CMAKE_ARGS="$BTLS_CMAKE_ARGS -DCYGWIN=TRUE -DCMAKE_TOOLCHAIN_FILE=\"$mono_btls_dir_abs/mxe-Win64.cmake\""
+ 				;;
+ 		esac
+ 		;;
+diff --git a/mono/btls/CMakeLists.txt b/mono/btls/CMakeLists.txt
+index 992f41e4c7f..9946f5d21a4 100644
+--- a/mono/btls/CMakeLists.txt
++++ b/mono/btls/CMakeLists.txt
+@@ -129,4 +129,5 @@ endif ()
+ 
+ if (CYGWIN)
+ 	target_link_libraries (mono-btls-shared wsock32 ws2_32)
++	target_link_options (mono-btls-shared PRIVATE -static-libgcc)
+ endif ()
+\ No newline at end of file

--- a/patch_mono.py
+++ b/patch_mono.py
@@ -32,6 +32,7 @@ def main(raw_args):
         'bcl-profile-platform-override.diff',
         'mono_ios_asl_log_deprecated.diff',
         'wasm_m2n_trampolines_hook.diff',
+        'btls-cmake-args-linux-mingw.diff'
     ]
 
     if os.path.isfile(os.path.join(mono_source_root, 'mono/tools/offsets-tool/offsets-tool.py')):


### PR DESCRIPTION
Patched Mono to make the BTLS CMake build work with MinGW on Linux.

This includes @akien-mga's patch for `mono/btls/CMakeLists.txt` to make it build with `-static-libgcc`.
