### PR TITLE
Mono: Bump to 6.12.0.174

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ on:
 
 env:
   # Use SHA or tag instead of the branch for caching purposes.
-  MONO_TAG: mono-6.12.0.147
+  MONO_TAG: mono-6.12.0.174
   PYTHON_VERSION: 3.9
   # Should match the version that Mono supports.
   EMSDK_VERSION: 1.39.9

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository contains scripts for building the Mono runtime to use with Godot
 The scripts are tested against specific versions of the toolchains used by Godot.
 While they may work with other versions, you might have issues applying patches or compiling, so we recommend using the versions below.
 
-- Mono: 6.12.0.147.
+- Mono: 6.12.0.174.
 - Emscripten: 1.39.9.
 - Android: API level 30.
 


### PR DESCRIPTION
Should also fix CI by including
https://github.com/mono/mono/commit/5a21247f3669777823babd1c75bc199c32aa7484

For the record I've been using 6.12.0.158 for several months for official builds. I don't know why I never PR'ed it here.