### PR TITLE
desktop: Only enable btls-lib on Windows

### DIFF
--- a/desktop.py
+++ b/desktop.py
@@ -89,12 +89,12 @@ def setup_desktop_template(env: dict, opts: DesktopOpts, product: str, target_pl
         '--with-tls=pthread',
         '--without-ikvm-native',
         '--enable-btls',
-        '--enable-btls-lib'
     ]
 
     if target_platform == 'windows':
         CONFIGURE_FLAGS += [
-            '--with-libgdiplus=%s' % opts.mxe_prefix
+            '--with-libgdiplus=%s' % opts.mxe_prefix,
+            '--enable-btls-lib',
         ]
     else:
         CONFIGURE_FLAGS += [


### PR DESCRIPTION
Follow-up to #47 and #49.
This caused issues on macOS ARM64, see https://github.com/godotengine/build-containers/issues/95.

Supersedes #64.