### PR TITLE
Add arm64 to osx build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -186,7 +186,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        target: [x86_64]
+        target: [arm64, x86_64]
     steps:
       - name: Set Environment Variables
         run: |
@@ -729,7 +729,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        artifact_name: [linux-x86, linux-x86_64, windows-x86, windows-x86_64, osx-x86_64,
+        artifact_name: [linux-x86, linux-x86_64, windows-x86, windows-x86_64, osx-arm64, osx-x86_64,
                         ios-arm64, ios-x86_64, ios-cross-arm64,
                         android-armeabi-v7a, android-arm64-v8a, android-x86, android-x86_64,
                         wasm-runtime, wasm-runtime-threads,


### PR DESCRIPTION
Here are github-action runs on my fork:
- [Static checks action](https://github.com/Atlinx/godot-mono-builds/actions/runs/3120741803)
- [Build action](https://github.com/Atlinx/godot-mono-builds/actions/runs/3120737874)
